### PR TITLE
Fix broken RAML/schema configuration

### DIFF
--- a/ramls/schema/searchResult.json
+++ b/ramls/schema/searchResult.json
@@ -40,8 +40,10 @@
             "description": "count of bibliographic records associated to the current record",
             "type": "integer"
           },
-          "queryForAssociatedDoc": "query to retrieve records associated to the current one",
-          "type": "string"
+          "queryForAssociatedDoc": {
+            "description": "query to retrieve records associated to the current one",
+            "type": "string"
+          }
         },
         "tagHighlighted": {
           "description": "list of tag in which query terms are present",

--- a/ramls/schema/searchResultVertical.json
+++ b/ramls/schema/searchResultVertical.json
@@ -40,8 +40,10 @@
             "description": "count of bibliographic records associated to the current record",
             "type": "integer"
           },
-          "queryForAssociatedDoc": "query to retrieve records associated to the current one",
-          "type": "string"
+          "queryForAssociatedDoc": {
+            "description": "query to retrieve records associated to the current one",
+            "type": "string"
+          }
         },
         "tagHighlighted": {
           "description": "list of tag in which query terms are present",


### PR DESCRIPTION
There was some misplaced "description" attributes. That produced the confusing messages shown in pull/#51

There is also a configuration issue in the RAML, which will address the remaining error reports.