### PR TITLE
fix heading correlation

### DIFF
--- a/src/main/java/org/folio/marccat/dao/persistence/TTL_HDG.java
+++ b/src/main/java/org/folio/marccat/dao/persistence/TTL_HDG.java
@@ -160,14 +160,11 @@ public class TTL_HDG extends Descriptor implements SkipInFiling, Serializable {
     return new CorrelationValues();
   }
 
-  /* (non-Javadoc)
-   * @see Descriptor#setCorrelationValues(CorrelationValues)
-   */
   @Override
   public void setCorrelationValues(CorrelationValues v) {
-	  throw new UnsupportedOperationException();
 
   }
+
 
   /* (non-Javadoc)
    * @see Descriptor#getSortFormParameters()


### PR DESCRIPTION
no longer saves the heading due to an inserted exception that prevented saving, updating and deleting.