### PR TITLE
fix insert record after sonarlint broken

### DIFF
--- a/src/main/java/org/folio/marccat/business/cataloguing/bibliographic/BibliographicItem.java
+++ b/src/main/java/org/folio/marccat/business/cataloguing/bibliographic/BibliographicItem.java
@@ -1,5 +1,6 @@
 package org.folio.marccat.business.cataloguing.bibliographic;
 
+import net.sf.hibernate.Session;
 import org.folio.marccat.business.cataloguing.common.Tag;
 import org.folio.marccat.business.cataloguing.common.TagImpl;
 import org.folio.marccat.config.log.Log;
@@ -26,6 +27,8 @@ public class BibliographicItem extends CatalogItem implements Serializable {
   public BibliographicItem() {
     super();
   }
+
+
 
   public BibliographicItem(Integer id) {
     super();
@@ -117,6 +120,7 @@ public class BibliographicItem extends CatalogItem implements Serializable {
     return record;
   }
 
+
   /* (non-Javadoc)
    * @see CatalogItem#checkForMandatoryTags()
    */
@@ -125,10 +129,10 @@ public class BibliographicItem extends CatalogItem implements Serializable {
    * like 000, 001, 005 cannot be added by the user and will be generated
    * if not present
    */
-  public void checkForMandatoryTags() {
+  public void checkForMandatoryTags(Session session) {
     final String[] tags = new String[]{"000", "008", "040"};
     for (int i = 0; i < tags.length; i++) {
-      if (findFirstTagByNumber(tags[i]) == null) {
+      if (findFirstTagByNumber(tags[i], session) == null) {
         throw new MandatoryTagException(tags[i]);
       }
     }

--- a/src/main/java/org/folio/marccat/dao/BibliographicCatalogDAO.java
+++ b/src/main/java/org/folio/marccat/dao/BibliographicCatalogDAO.java
@@ -508,6 +508,13 @@ public class BibliographicCatalogDAO extends CatalogDAO {
     return singleView;
   }
 
+  /**
+   * @deprecated
+   * @param apfClass
+   * @param id
+   * @param userView
+   * @return
+   */
   @Deprecated
   public List loadAccessPointTags(Class apfClass, int id, int userView) {
     return Collections.emptyList();
@@ -632,6 +639,11 @@ public class BibliographicCatalogDAO extends CatalogDAO {
     }
   }
 
+  /**
+   * @deprecated
+   * @param item
+   * @return
+   */
   @Deprecated
   public Collection<SubjectAccessPoint> getEquivalentSubjects(final CatalogItem item) {
     return Collections.emptyList();
@@ -640,25 +652,40 @@ public class BibliographicCatalogDAO extends CatalogDAO {
   @SuppressWarnings("unchecked")
   private List<PublisherManager> getPublisherTags(final int amicusNumber, final int userView, final Session session) throws HibernateException {
     List<PublisherAccessPoint> publisherAccessPoints = (List<PublisherAccessPoint>) getAccessPointTags(PublisherAccessPoint.class, amicusNumber, userView, session);
-    return publisherAccessPoints.stream().map(accessPoint -> new PublisherManager(accessPoint)).collect(Collectors.toList());
+    return publisherAccessPoints.stream().map(PublisherManager::new).collect(Collectors.toList());
   }
 
 
+  /**
+   * @deprecated
+   * @param key
+   * @return
+   */
   @Deprecated
   public CatalogItem getCatalogItemByKey(Object[] key) {
     return null;
   }
 
+  /**
+   * @deprecated
+   * @param id
+   * @param userView
+   * @return
+   */
   @Deprecated
   public BibliographicItem getBibliographicItemWithoutRelationships(final int id, int userView) {
     return null;
   }
 
+  /**
+   * @deprecated
+   * @param bibItemNumber
+   * @param cataloguingView
+   */
   @Deprecated
   public void updateCacheTable(
     final int bibItemNumber,
     final int cataloguingView) {
-    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/src/main/java/org/folio/marccat/dao/DAOBibItem.java
+++ b/src/main/java/org/folio/marccat/dao/DAOBibItem.java
@@ -96,7 +96,7 @@ public class DAOBibItem extends AbstractDAO {
     if (l.stream().anyMatch(Objects::nonNull)) {
       return (BIB_ITM) isolateView(l.stream().findFirst().get(), userView, session);
     } else {
-      throw new RecordNotFoundException("BIB_ITM not found");
+      return null;
     }
   }
 }

--- a/src/main/java/org/folio/marccat/dao/DAOBibItem.java
+++ b/src/main/java/org/folio/marccat/dao/DAOBibItem.java
@@ -96,7 +96,7 @@ public class DAOBibItem extends AbstractDAO {
     if (l.stream().anyMatch(Objects::nonNull)) {
       return (BIB_ITM) isolateView(l.stream().findFirst().get(), userView, session);
     } else {
-      return null;
+      throw new RecordNotFoundException("BIB_ITM not found");
     }
   }
 }

--- a/src/main/java/org/folio/marccat/dao/DAOBibItem.java
+++ b/src/main/java/org/folio/marccat/dao/DAOBibItem.java
@@ -1,10 +1,3 @@
-/*
- * (c) LibriCore
- *
- * Created on Dec 3, 2004
- *
- * DAOBibItem.java
- */
 package org.folio.marccat.dao;
 
 import net.sf.hibernate.Hibernate;
@@ -13,10 +6,10 @@ import net.sf.hibernate.Session;
 import net.sf.hibernate.type.Type;
 import org.folio.marccat.business.common.Persistence;
 import org.folio.marccat.business.common.View;
+import org.folio.marccat.config.log.Log;
 import org.folio.marccat.dao.common.TransactionalHibernateOperation;
 import org.folio.marccat.dao.persistence.BIB_ITM;
 import org.folio.marccat.dao.persistence.Cache;
-import org.folio.marccat.exception.RecordNotFoundException;
 import org.folio.marccat.exception.ReferentialIntegrityException;
 
 import java.util.List;
@@ -28,6 +21,10 @@ import java.util.Objects;
  * @since 1.0
  */
 public class DAOBibItem extends AbstractDAO {
+
+  private static final Log logger = new Log(DAOBibItem.class);
+
+
   @Deprecated
   @Override
   public void delete(Persistence p) {
@@ -96,7 +93,9 @@ public class DAOBibItem extends AbstractDAO {
     if (l.stream().anyMatch(Objects::nonNull)) {
       return (BIB_ITM) isolateView(l.stream().findFirst().get(), userView, session);
     } else {
-      throw new RecordNotFoundException("BIB_ITM not found");
+      logger.debug("BIB_ITM not found");
+      logger.info("DONT PUT RecordNotFoundException HERE! BUT RUTURN NULL");
+      return null;
     }
   }
 }

--- a/src/main/java/org/folio/marccat/dao/DAOBibliographicRelationship.java
+++ b/src/main/java/org/folio/marccat/dao/DAOBibliographicRelationship.java
@@ -81,7 +81,7 @@ public class DAOBibliographicRelationship extends AbstractDAO {
     return relationship;
   }
 
-  public StringText buildRelationStringText(int bibItemNumber, int userView) {
+  public StringText buildRelationStringText(int bibItemNumber, int userView, Session session) {
     StringText stringText = new StringText();
     BibliographicCatalogDAO catalog = new BibliographicCatalogDAO();
 
@@ -89,7 +89,7 @@ public class DAOBibliographicRelationship extends AbstractDAO {
 
     /* Name Tags */
 
-    VariableField t = (VariableField) item.findFirstTagByNumber("1");
+    VariableField t = (VariableField) item.findFirstTagByNumber("1", session);
     if (t instanceof NameAccessPoint) {
       stringText.addSubfield(
         new Subfield("a", t.getStringText().toDisplayString()));
@@ -97,13 +97,13 @@ public class DAOBibliographicRelationship extends AbstractDAO {
 
     /* Title Tags */
 
-    t = (VariableField) item.findFirstTagByNumber("130");
+    t = (VariableField) item.findFirstTagByNumber("130",session);
 
     if (t != null) {
       stringText.addSubfield(
         new Subfield("t", t.getStringText().toDisplayString()));
     } else {
-      t = (VariableField) item.findFirstTagByNumber("245");
+      t = (VariableField) item.findFirstTagByNumber("245",session);
       if (t != null) {
         stringText.addSubfield(
           new Subfield("t", t.getStringText().toDisplayString()));
@@ -111,7 +111,7 @@ public class DAOBibliographicRelationship extends AbstractDAO {
       else logger.error("245 is a required tag");
     }
 
-    t = (VariableField) item.findFirstTagByNumber("210");
+    t = (VariableField) item.findFirstTagByNumber("210",session);
     if (t != null) {
       stringText.addSubfield(
         new Subfield("p", t.getStringText().toDisplayString()));
@@ -119,7 +119,7 @@ public class DAOBibliographicRelationship extends AbstractDAO {
 
     /* Note Tags */
 
-    t = (VariableField) item.findFirstTagByNumber("250");
+    t = (VariableField) item.findFirstTagByNumber("250",session);
     if (t != null) {
       stringText.addSubfield(
         new Subfield("b", t.getStringText().toDisplayString()));
@@ -127,7 +127,7 @@ public class DAOBibliographicRelationship extends AbstractDAO {
 
     /* Publisher Tags */
 
-    t = (VariableField) item.findFirstTagByNumber("260");
+    t = (VariableField) item.findFirstTagByNumber("260",session);
     if (t != null) {
       stringText.addSubfield(
         new Subfield("d", t.getStringText().toDisplayString()));
@@ -135,12 +135,12 @@ public class DAOBibliographicRelationship extends AbstractDAO {
 
     /* ControlNumber Tags */
 
-    t = (VariableField) item.findFirstTagByNumber("020");
+    t = (VariableField) item.findFirstTagByNumber("020",session);
     if (t != null) {
       stringText.addSubfield(
         new Subfield("z", t.getStringText().toDisplayString()));
     } else {
-      t = (VariableField) item.findFirstTagByNumber("022");
+      t = (VariableField) item.findFirstTagByNumber("022",session);
       if (t != null) {
         stringText.addSubfield(
           new Subfield("x", t.getStringText().toDisplayString()));
@@ -149,19 +149,19 @@ public class DAOBibliographicRelationship extends AbstractDAO {
 
     /* ClassificationNumber Tags */
 
-    t = (VariableField) item.findFirstTagByNumber("088");
+    t = (VariableField) item.findFirstTagByNumber("088",session);
     if (t != null) {
       stringText.addSubfield(
         new Subfield("r", t.getStringText().toDisplayString()));
     }
 
-    t = (VariableField) item.findFirstTagByNumber("027");
+    t = (VariableField) item.findFirstTagByNumber("027",session);
     if (t != null) {
       stringText.addSubfield(
         new Subfield("u", t.getStringText().toDisplayString()));
     }
 
-    t = (VariableField) item.findFirstTagByNumber("030");
+    t = (VariableField) item.findFirstTagByNumber("030",session);
     if (t != null) {
       stringText.addSubfield(
         new Subfield("y", t.getStringText().toDisplayString()));

--- a/src/main/java/org/folio/marccat/dao/persistence/BibliographicRelationship.java
+++ b/src/main/java/org/folio/marccat/dao/persistence/BibliographicRelationship.java
@@ -111,7 +111,7 @@ public class BibliographicRelationship extends VariableField implements Persiste
     StringText s = new StringText();
     DAOBibliographicRelationship b = new DAOBibliographicRelationship();
     try {
-      s = b.buildRelationStringText(this.getTargetBibItemNumber(), userView);
+      s = b.buildRelationStringText(this.getTargetBibItemNumber(), userView, b.currentSession());
       s.add(getRelationshipStringText());
       return s;
     } catch (DataAccessException ex) {

--- a/src/main/java/org/folio/marccat/dao/persistence/BibliographicRelationshipTag.java
+++ b/src/main/java/org/folio/marccat/dao/persistence/BibliographicRelationshipTag.java
@@ -57,7 +57,7 @@ public class BibliographicRelationshipTag extends VariableField implements Persi
     StringText s = new StringText();
     if (getSourceRelationship().getTargetBibItemNumber() > 0) {
       DAOBibliographicRelationship b = new DAOBibliographicRelationship();
-      s = b.buildRelationStringText(sourceRelationship.getTargetBibItemNumber(), userView);
+      s = b.buildRelationStringText(sourceRelationship.getTargetBibItemNumber(), userView, b.currentSession());
     }
     setReciprocalStringText(s);
   }

--- a/src/main/java/org/folio/marccat/dao/persistence/CatalogItem.java
+++ b/src/main/java/org/folio/marccat/dao/persistence/CatalogItem.java
@@ -29,6 +29,7 @@ public abstract class CatalogItem implements Serializable {
     (Tag tag1, Tag tag2) -> (tag1.getMarcEncoding().getMarcTag().compareTo(tag2.getMarcEncoding().getMarcTag()));
   protected List<Tag> deletedTags = new ArrayList<>();
   protected ModelItem modelItem;
+  protected Session session;
   protected List<Tag> tags = new ArrayList<>();
   private transient Log logger = new Log(CatalogItem.class);
 
@@ -61,6 +62,10 @@ public abstract class CatalogItem implements Serializable {
     return xmlDocument;
   }
 
+  /**
+   * @deprecated
+   * @param tags
+   */
   @Deprecated
   public void addAllTags(Tag[] tags) {
     for (int i = 0; i < tags.length; i++) {
@@ -68,6 +73,10 @@ public abstract class CatalogItem implements Serializable {
     }
   }
 
+  /**
+   * @deprecated
+   * @param aTag
+   */
   @Deprecated
   public void addDeletedTag(Tag aTag) {
     if (!deletedTags.contains(aTag)) {
@@ -76,11 +85,19 @@ public abstract class CatalogItem implements Serializable {
   }
 
 
+  /**
+   *
+   * @param newTag
+   */
   public void addTag(Tag newTag) {
     tags.add(newTag);
   }
 
-  abstract public void checkForMandatoryTags();
+  /**
+   *
+   * @param session
+   */
+  abstract public void checkForMandatoryTags(Session session);
 
   /**
    * Checks if the specified tag is illegally repeated in the item and throws an exception if so.
@@ -105,13 +122,7 @@ public abstract class CatalogItem implements Serializable {
    *
    * @param s -- the tag number to search.
    */
-  public Tag findFirstTagByNumber(final String s) {
-    try {
-      return getTags().stream().filter(tag -> tag.getMarcEncoding().getMarcTag().startsWith(s)).findFirst().orElse(null);
-    } catch (Exception e) {
-      return null;
-    }
-  }
+
 
   /**
    * Finds the first tag occurrence of the given tag number.
@@ -294,7 +305,7 @@ public abstract class CatalogItem implements Serializable {
    * @throws DataAccessException in case of data access exception.
    */
   public void validate() {
-    checkForMandatoryTags();
+    checkForMandatoryTags(this.session);
     for (int i = 0; i < getTags().size(); i++) {
       checkRepeatability(i);
       getTag(i).validate(i);

--- a/src/main/java/org/folio/marccat/integration/StorageService.java
+++ b/src/main/java/org/folio/marccat/integration/StorageService.java
@@ -1250,7 +1250,7 @@ public class StorageService implements Closeable {
    * @throws DataAccessException in case of data access exception.
    */
   public void saveBibliographicRecord(final BibliographicRecord record, final RecordTemplate template, final int view, final GeneralInformation generalInformation, final String lang,  final Map<String, String> configuration) throws DataAccessException {
-    CatalogItem item = null;
+    CatalogItem item;
     try {
       item = getCatalogItemByKey(record.getId(), view);
     } catch (DataAccessException exception) {

--- a/src/main/java/org/folio/marccat/integration/StorageService.java
+++ b/src/main/java/org/folio/marccat/integration/StorageService.java
@@ -1250,12 +1250,12 @@ public class StorageService implements Closeable {
    * @throws DataAccessException in case of data access exception.
    */
   public void saveBibliographicRecord(final BibliographicRecord record, final RecordTemplate template, final int view, final GeneralInformation generalInformation, final String lang,  final Map<String, String> configuration) throws DataAccessException {
-    CatalogItem item;
+    CatalogItem item = null;
     try {
       item = getCatalogItemByKey(record.getId(), view);
     } catch (DataAccessException exception) {
       logger.error(Message.MOD_MARCCAT_00010_DATA_ACCESS_FAILURE, exception);
-      throw new DataAccessException(exception);
+      // do not put any exception here!!!!!!!!!!!!! , because the microservice doesn't insert the record
     }
 
     try {

--- a/src/main/java/org/folio/marccat/resources/BibliographicRecordAPI.java
+++ b/src/main/java/org/folio/marccat/resources/BibliographicRecordAPI.java
@@ -122,7 +122,6 @@ public class BibliographicRecordAPI extends BaseResource {
       bibliographicRecord.setCanadianContentIndicator("0");
       resetStatus(bibliographicRecord);
       return bibliographicRecord;
-
     }, tenant, configurator, "bibliographic");
   }
 

--- a/src/main/java/org/folio/marccat/resources/shared/RecordUtils.java
+++ b/src/main/java/org/folio/marccat/resources/shared/RecordUtils.java
@@ -40,6 +40,15 @@ public class RecordUtils {
       Global.FIXED_LEADER_PORTION;
   }
 
+  public static String buildString(String ...s) {
+    int i = s.length;
+    for(String c:s){
+
+    }
+    return String.format("%s%s %s%s%s%s%s%s   %s%s",s);
+  }
+
+
   /**
    * Reset status fields to UNCHANGED.
    *

--- a/src/main/java/org/folio/marccat/shared/GeneralInformation.java
+++ b/src/main/java/org/folio/marccat/shared/GeneralInformation.java
@@ -340,22 +340,18 @@ public class GeneralInformation {
    * @return the displayString segment for serial (continuing resources) material
    */
   public String serialDisplayString() {
-    StringBuilder builder = new StringBuilder();
-    builder.append("")
-      .append(getSerialFrequencyCode())        /* 18 - Frequency */
-      .append(getSerialRegularityCode())        /* 19 - Regularity */
-      .append(" ")                    /* 20 - Undefined */
-      .append(getSerialTypeCode())            /* 21 - Type of continuing resource */
-      .append(getSerialFormOriginalItemCode())      /* 22 - Form of original item */
-      .append(getFormOfItemCode())            /* 23 - Form of item */
-      .append(getNatureOfContentsCode())        /* 24 - Nature of entire work 25-27 - Nature of contents */
-      .append(getGovernmentPublicationCode())      /* 28 - Government publication */
-      .append(getConferencePublicationCode())      /* 29 - Conference publication */
-      .append("   ")                  /* 30-32 - Undefined  */
-      .append(getSerialOriginalAlphabetOfTitleCode())  /* 33 - Original alphabet or script of title */
-      .append(getSerialEntryConventionCode());    /* 34 - Entry convention */
 
-    return builder.toString();
+    return String.format("%s%s %s%s%s%s%s%s   %s%s",
+      getSerialFrequencyCode(),
+      getSerialRegularityCode(),
+      getSerialTypeCode(),
+      getSerialFormOriginalItemCode(),
+      getFormOfItemCode(),
+      getNatureOfContentsCode(),
+      getGovernmentPublicationCode(),
+      getConferencePublicationCode(),
+      getSerialOriginalAlphabetOfTitleCode(),
+      getSerialEntryConventionCode());
   }
 
   public String getMusicPartsCode() {

--- a/src/main/java/org/folio/marccat/util/F.java
+++ b/src/main/java/org/folio/marccat/util/F.java
@@ -91,6 +91,49 @@ public abstract class F {
     return String.format(padNum, number);
   }
 
+
+
+  /**
+   * Returns a string with leading character at begin of specified number.
+   *
+   * @param number      -- the number to format.
+   * @return the string representing number.
+   * e.g: number = 23 prints: prints: |                  23|
+   */
+  public static String widthPadding(final int number) {
+    return String.format("|%20d|", number); //
+  }
+
+  /**
+   * Returns a string with leading character at begin of specified number.
+   *
+   * @param number      -- the number to format.
+   * @return the string representing number.
+   * e.g: number = 23 prints: |00000000000000000023|
+   */
+  public static String zeroPadding(final int number) {
+    return String.format("|%020d|", number);
+  }
+
+  /**
+   * Returns a string with leading character at begin of specified number.
+   *
+   * @param number      -- the number to format.
+   * @return the string representing number.
+   * e.g: number = 23 prints: prints: |23                  |
+   */
+  public static String leftJustifyPadding(final int number) {
+    return String.format("|%-20d|", number);
+  }
+  /**
+   * Returns true if the given string is not null or empty.
+   *
+   * @param value the input string.
+   * @return true if the given string is not null or empty.
+   */
+  public static <T> boolean isNotNullParametric(final T value) {
+    return value != null;
+  }
   /**
    * Returns true if the given string is not null or empty.
    *

--- a/src/main/java/org/folio/marccat/util/XmlUtils.java
+++ b/src/main/java/org/folio/marccat/util/XmlUtils.java
@@ -181,24 +181,4 @@ public final class XmlUtils {
 
     return cleanedText;
   }
-
-  /**
-   * Inizia la ricerca nella stringa per inserire i delimitatori di tutti i pattern.
-   *
-   * @param cclQuery
-   * @param subfield
-   * @return la stringa con tutti i delimitatori
-   */
-  public static String parseString(final String cclQuery, final Subfield subfield) {
-    final String[] termsToBeHighlighted = getHighlightedTerms(cclQuery);
-    String text = subfield.getContent();
-    for (int i = 0; i < termsToBeHighlighted.length; i++) {
-      String termineCorrente = termsToBeHighlighted[i];
-      int[] indiciDelimitatore = indexesToBeHighlighted(termineCorrente, text);
-
-      if (indiciDelimitatore[0] != -1)
-        text = addDelimiters(indiciDelimitatore[0], indiciDelimitatore[1], text);
-    }
-    return text;
-  }
 }


### PR DESCRIPTION
fix insert record after sonarlint broken, inside the storage service due to the refactoring for the sonarlint an exception was inserted in the record insertion phase, which prevented the completion of the operation. ([see comment line 1258  StorageService.java](https://github.com/folio-org/mod-marccat/blob/36714b8b112863a75cf0a287579083eb43c0fa37/src/main/java/org/folio/marccat/integration/StorageService.java#L1258) and comment line [96-97 DAOBibItem.java](https://github.com/folio-org/mod-marccat/blob/36714b8b112863a75cf0a287579083eb43c0fa37/src/main/java/org/folio/marccat/dao/DAOBibItem.java#L99))