### PR TITLE
FOLIO-2272 Add default LaunchDescriptor settings

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -196,8 +196,10 @@
   ],
   "launchDescriptor": {
     "dockerImage": "@artifactId@:@version@",
+    "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
+        "Memory": 536870912,
         "PortBindings": {
           "8081/tcp": [
             {
@@ -207,6 +209,43 @@
         }
       }
     },
-    "dockerPull": false
+    "env": [
+      {
+        "name": "JAVA_OPTIONS",
+        "value": "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      },
+      {
+        "name": "DB_HOST",
+        "value": "postgres"
+      },
+      {
+        "name": "DB_PORT",
+        "value": "5432"
+      },
+      {
+        "name": "DB_USERNAME",
+        "value": "folio_admin"
+      },
+      {
+        "name": "DB_PASSWORD",
+        "value": "folio_admin"
+      },
+      {
+        "name": "DB_DATABASE",
+        "value": "okapi_modules"
+      },
+      {
+        "name": "DB_QUERYTIMEOUT",
+        "value": "60000"
+      },
+      {
+        "name": "DB_CHARSET",
+        "value": "UTF-8"
+      },
+      {
+        "name": "DB_MAXPOOLSIZE",
+        "value": "5"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Enables ready default deployment.
Refer to [FOLIO-2272](https://issues.folio.org/browse/FOLIO-2272) and [documentation](https://dev.folio.org/guides/module-descriptor/#launchdescriptor-properties).

Review is not needed. This is a devops task: Doing similar for all modules.