### PR TITLE
deploy to ci kubernetes on release or snap build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ buildMvn {
   publishAPI = 'yes'
   mvnDeploy = 'yes'
   runLintRamlCop = 'yes'
+  doKubeDeploy = true
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
This pr turns on the Kube Deploy step in the buildMvn pipeline which will deploy a container to the CI Kubernetes cluster when a snapshot or release is built.